### PR TITLE
feat: 토큰 재발급 기능 Service, Controller 추가

### DIFF
--- a/src/main/java/com/project/semipermbackend/auth/controller/AuthController.java
+++ b/src/main/java/com/project/semipermbackend/auth/controller/AuthController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
     private final AuthService authService;
 
-//    @PostMapping("/token-reissue")
     @PutMapping("/token-reissue")
     public ResponseEntity<ApiResultDto<AuthResponseDto.AuthTokens>> reissue() {
         Long accountId = JwtTokenProvider.getAccountIdFromContext();

--- a/src/main/java/com/project/semipermbackend/auth/controller/AuthController.java
+++ b/src/main/java/com/project/semipermbackend/auth/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.project.semipermbackend.auth.controller;
+
+import com.project.semipermbackend.auth.dto.AuthResponseDto;
+import com.project.semipermbackend.auth.jwt.JwtTokenProvider;
+import com.project.semipermbackend.auth.service.AuthService;
+import com.project.semipermbackend.common.dto.ApiResultDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+//    @PostMapping("/token-reissue")
+    @PutMapping("/token-reissue")
+    public ResponseEntity<ApiResultDto<AuthResponseDto.AuthTokens>> reissue() {
+        Long accountId = JwtTokenProvider.getAccountIdFromContext();
+
+        AuthResponseDto.AuthTokens reissuedTokens  = authService.reissueTokens(accountId);
+        return new ResponseEntity<>(ApiResultDto.success(reissuedTokens), HttpStatus.ACCEPTED);
+    }
+
+}

--- a/src/main/java/com/project/semipermbackend/auth/service/AuthService.java
+++ b/src/main/java/com/project/semipermbackend/auth/service/AuthService.java
@@ -2,8 +2,13 @@ package com.project.semipermbackend.auth.service;
 
 import com.project.semipermbackend.auth.dto.AuthResponseDto;
 import com.project.semipermbackend.auth.entity.CustomOAuth2UserInfo;
+import com.project.semipermbackend.auth.jwt.JwtTokenProvider;
+import com.project.semipermbackend.common.error.ErrorCode;
+import com.project.semipermbackend.common.error.exception.EntityNotFoundException;
 import com.project.semipermbackend.domain.account.Account;
 import com.project.semipermbackend.domain.account.AccountRepository;
+import com.project.semipermbackend.domain.member.Member;
+import com.project.semipermbackend.domain.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -14,7 +19,10 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Service
 public class AuthService {
+    private final JwtTokenProvider jwtTokenProvider;
     private final AccountRepository accountRepository;
+    private final MemberRepository memberRepository;
+
     @Transactional
     public AuthResponseDto.OAuth2Success createAccount (Account account) {
         Account savedAccount = accountRepository.save(account);
@@ -26,4 +34,14 @@ public class AuthService {
         return accountRepository.findBySocialTypeAndEmail(principal.getSocialType(), principal.getEmail());
     }
 
+    @Transactional
+    public AuthResponseDto.AuthTokens reissueTokens(Long accountId) {
+        // Account, Member 조회
+        Account account = accountRepository.findByAccountId(accountId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_ACCOUNT, accountId));
+        Member member = memberRepository.findByAccount(account)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+
+        return jwtTokenProvider.reissueTokens(member, account);
+    }
 }

--- a/src/main/java/com/project/semipermbackend/domain/account/Account.java
+++ b/src/main/java/com/project/semipermbackend/domain/account/Account.java
@@ -64,7 +64,7 @@ public class Account extends BaseTimeEntity {
     @Column(name = "is_order_than_14", nullable = false, length = 2)
     private FlagYn isOrderThan14 = FlagYn.NO;
 
-    public void login(String refreshToken) {
+    public void setLoginStatus(String refreshToken) {
         this.refreshToken = refreshToken;
         this.lastLoginDate = LocalDate.now();
     }
@@ -77,5 +77,9 @@ public class Account extends BaseTimeEntity {
         this.personalInfoServiceUsageAgreeYn = memberCreation.getPersonalInfoServiceUsageAgreeYn();
         this.isOrderThan14 = memberCreation.getIsOrderThan14();
         this.agreeToADYn = memberCreation.getAgreeToADYn();
+    }
+
+    public void logout() {
+        this.refreshToken = null;
     }
 }


### PR DESCRIPTION
- `Put` 메서드
- Access Token 재발급 요청 시에는 헤더에 담겨오는 Refresh Token에 대해 유효성 체크한다. (Filter에서 진행)
- RefreshToken도 함께 재발급하여 `account` 테이블에 update한다.